### PR TITLE
Add blog post listing page with card components

### DIFF
--- a/app/post/page.tsx
+++ b/app/post/page.tsx
@@ -1,0 +1,41 @@
+import type { Post } from "@/types";
+
+import { PostCard } from "@/app/post/postcard";
+import { getPostSlugs } from "@/lib/post";
+
+import path from "node:path";
+
+export default async function PostsPage() {
+  const posts: Post[] = await getPost();
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <div className="text-center mb-12">
+        <p className="text-base font-normal text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+          Explore my latest thoughts and insights on various topics.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        {posts.map((post) => (
+          <PostCard key={post.slug} post={post} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+async function getPost() {
+  const postsDirectory = path.join(process.cwd(), "content", "post");
+
+  const postsSlugs = await getPostSlugs(postsDirectory);
+
+  const posts = await Promise.all(
+    postsSlugs.map(async (slug: string) => {
+      const { metadata } = await import(`@/content/post/${slug}.mdx`);
+      return { ...metadata, slug } as Post;
+    })
+  );
+
+  return posts;
+}

--- a/app/post/page.tsx
+++ b/app/post/page.tsx
@@ -1,7 +1,8 @@
-import type { Post } from "@/types";
+import type { Post, PostMetadata } from "@/types";
 
 import { PostCard } from "@/app/post/postcard";
 import { getPostSlugs } from "@/lib/post";
+import { FilePlus } from "lucide-react";
 
 import path from "node:path";
 
@@ -17,9 +18,19 @@ export default async function PostsPage() {
       </div>
 
       <div className="flex flex-col gap-4">
-        {posts.map((post) => (
-          <PostCard key={post.slug} post={post} />
-        ))}
+        {posts.length === 0 ? (
+          <div className="text-center py-12">
+            <FilePlus className="size-12 mx-auto stroke-1 text-gray-600 dark:text-gray-400 mb-4" />
+            <h4 className="font-semibold text-gray-800 dark:text-gray-100">
+              No posts available
+            </h4>
+            <p className="text-gray-500 text-sm my-2 dark:text-gray-400">
+              Please check back later.
+            </p>
+          </div>
+        ) : (
+          posts.map((post) => <PostCard key={post.slug} post={post} />)
+        )}
       </div>
     </div>
   );
@@ -28,14 +39,47 @@ export default async function PostsPage() {
 async function getPost() {
   const postsDirectory = path.join(process.cwd(), "content", "post");
 
-  const postsSlugs = await getPostSlugs(postsDirectory);
+  let postsSlugs: string[] = [];
+
+  try {
+    postsSlugs = await getPostSlugs(postsDirectory);
+    if (!postsSlugs || postsSlugs.length === 0) return [];
+  } catch (error) {
+    console.error(
+      "Failed to get post slugs from directory:",
+      postsDirectory,
+      error
+    );
+    return [];
+  }
 
   const posts = await Promise.all(
     postsSlugs.map(async (slug: string) => {
-      const { metadata } = await import(`@/content/post/${slug}.mdx`);
-      return { ...metadata, slug } as Post;
+      try {
+        const { metadata } = await import(`@/content/post/${slug}.mdx`);
+
+        if (!validatePostMetadata(metadata, slug)) return null;
+
+        return { ...metadata, slug } as Post;
+      } catch (error) {
+        console.error(error);
+        return null;
+      }
     })
   );
 
-  return posts;
+  return posts.filter(Boolean) as Post[];
+}
+
+function validatePostMetadata(
+  metadata: PostMetadata,
+  slug: string
+): metadata is Post {
+  const required = ["title", "summary", "publishedAt", "readTime"];
+  const missing = required.filter((field) => !(field in metadata));
+  if (missing.length > 0) {
+    console.warn(`Post ${slug} missing required fields:`, missing);
+    return false;
+  }
+  return true;
 }

--- a/app/post/postcard.tsx
+++ b/app/post/postcard.tsx
@@ -1,0 +1,40 @@
+import type { Post } from "@/types";
+
+import format from "date-fns/format";
+
+import {
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Card,
+} from "@/components/ui/card";
+
+import Link from "next/link";
+
+export const PostCard = ({ post }: { post: Post }) => {
+  return (
+    <Link href={`/post/${post.slug}`}>
+      <Card className="group border relative overflow-hidden rounded-sm p-6 gap-2 shadow-none hover:shadow-xs transition-all hover:bg-blue-50 dark:hover:bg-blue-950/80 cursor-pointer">
+        <CardHeader className="p-0">
+          <CardTitle className="text-blue-600 dark:text-blue-400">
+            {post.title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <p className="text-gray-500 dark:text-gray-400 mb-4 line-clamp-2">
+            {post.summary}
+          </p>
+        </CardContent>
+        <CardFooter className="p-0 divide-x-2 divide-gray-100 dark:divide-gray-700 flex items-center gap-2">
+          <p className="text-sm text-black/70 dark:text-white/70 pr-2">
+            {format(new Date(post.publishedAt), "PP")}
+          </p>
+          <p className="text-sm text-black/70 dark:text-white/70">
+            {post.readTime} min read
+          </p>
+        </CardFooter>
+      </Card>
+    </Link>
+  );
+};

--- a/app/post/postcard.tsx
+++ b/app/post/postcard.tsx
@@ -12,26 +12,32 @@ import {
 
 import Link from "next/link";
 
-export const PostCard = ({ post }: { post: Post }) => {
+export interface PostCardProps {
+  post: Post;
+}
+
+export const PostCard = ({ post }: PostCardProps) => {
+  const { title, summary, slug, publishedAt, readTime } = post;
+
   return (
-    <Link href={`/post/${post.slug}`}>
+    <Link href={`/post/${slug}`}>
       <Card className="group border relative overflow-hidden rounded-sm p-6 gap-2 shadow-none hover:shadow-xs transition-all hover:bg-blue-50 dark:hover:bg-blue-950/80 cursor-pointer">
         <CardHeader className="p-0">
           <CardTitle className="text-blue-600 dark:text-blue-400">
-            {post.title}
+            {title}
           </CardTitle>
         </CardHeader>
         <CardContent className="p-0">
           <p className="text-gray-500 dark:text-gray-400 mb-4 line-clamp-2">
-            {post.summary}
+            {summary}
           </p>
         </CardContent>
         <CardFooter className="p-0 divide-x-2 divide-gray-100 dark:divide-gray-700 flex items-center gap-2">
           <p className="text-sm text-black/70 dark:text-white/70 pr-2">
-            {format(new Date(post.publishedAt), "PP")}
+            {publishedAt ? format(new Date(publishedAt), "PP") : ""}
           </p>
           <p className="text-sm text-black/70 dark:text-white/70">
-            {post.readTime} min read
+            {readTime} min read
           </p>
         </CardFooter>
       </Card>

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "@/lib/utils";
+
+function Card({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+};

--- a/types.ts
+++ b/types.ts
@@ -14,6 +14,8 @@ export interface Post {
   image?: string;
 }
 
+export type PostMetadata = Omit<Post, "slug">;
+
 export type ExcludeFromArray<K extends unknown[], ToExclude> = Exclude<
   K[number],
   ToExclude


### PR DESCRIPTION
# Add Blog Post Listing Page

### TL;DR

Created a new blog post listing page with card components to display all posts.

### What changed?

- Added `/app/post/page.tsx` to display a list of all blog posts
- Created `/app/post/postcard.tsx` component to render individual post cards
- Implemented a reusable Card component system in `/components/ui/card.tsx`
- Added functionality to fetch and display post metadata from MDX files

### How to test?

1. Navigate to `/post` route in the application
2. Verify that all blog posts are displayed as cards
3. Check that each card shows the post title, summary, publication date, and read time
4. Confirm that clicking on a post card navigates to the individual post page

### Why make this change?

This change provides a centralized location for users to browse all available blog posts. The card-based interface offers a clean, visually appealing way to display post previews with essential metadata, improving content discoverability and user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a blog posts page displaying a list of posts with summaries, publication dates, and estimated reading times.
  - Added interactive post cards for each blog entry, featuring clickable links and enhanced styling.
  - Implemented a reusable Card UI component set for consistent and visually appealing layouts across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->